### PR TITLE
Specified host for database.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: localhost
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5


### PR DESCRIPTION
- `rake db` related tasks fail on certain systems
  if the host isn't specified.
